### PR TITLE
Undo the pinning for the v1.1.x wpars issue

### DIFF
--- a/lib/poise_service/aix/version.rb
+++ b/lib/poise_service/aix/version.rb
@@ -8,6 +8,6 @@
 
 module PoiseService
   module AIX
-    VERSION = '1.1.3'
+    VERSION = '1.1.4'
   end
 end

--- a/poise-service-aix.gemspec
+++ b/poise-service-aix.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'poise-boiler', '~> 1.0'
 
-  spec.metadata['halite_dependencies'] = 'aix ~> 1.0.0'
+  spec.metadata['halite_dependencies'] = 'aix ~> 1.0'
 end

--- a/poise-service-aix.gemspec
+++ b/poise-service-aix.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'poise-boiler', '~> 1.0'
 
-  spec.metadata['halite_dependencies'] = 'aix = 1.0.0'
+  spec.metadata['halite_dependencies'] = 'aix ~> 1.0.0'
 end


### PR DESCRIPTION
The upstream v1.2.x has fixed the issue, so we  can return to letting this float. This undoes #7.